### PR TITLE
Refactor: Reorder onboarding questions and update parsing/tests

### DIFF
--- a/src/app/api/onboarding/message/route.ts
+++ b/src/app/api/onboarding/message/route.ts
@@ -302,54 +302,31 @@ export async function POST(request: NextRequest) {
                 : null;
             break;
           case 1:
-            parseLanguages(responseToParse, dataToUpdate);
+            dataToUpdate.experience_level =
+              (responseToParse as { buttonValue: string })?.buttonValue ?? null;
             break;
-          case 2: {
-            // For blockchain platforms, pass selectedValues if available
-            let selectedValues: string[] | undefined = undefined;
-            let buttonValue = "";
-            if (Array.isArray(responseToParse)) {
-              selectedValues = responseToParse;
-              buttonValue = "Yes"; // Assume multi-select only happens if user said Yes
-            } else if (
-              typeof responseToParse === "object" &&
-              responseToParse !== null
-            ) {
-              if (
-                "buttonValue" in responseToParse &&
-                typeof responseToParse.buttonValue === "string"
-              ) {
-                buttonValue = responseToParse.buttonValue;
-              }
-              if (
-                "selectedValues" in responseToParse &&
-                Array.isArray(responseToParse.selectedValues)
-              ) {
-                selectedValues = responseToParse.selectedValues;
-              }
-            } else if (typeof responseToParse === "string") {
-              buttonValue = responseToParse;
-            }
+          case 2:
+            parseLanguages(responseToParse, dataToUpdate);
+            console.log("[PATCH] Stored languages:", dataToUpdate.languages);
+            break;
+          case 3:
             parseBlockchain(
-              { buttonValue, selectedValues },
+              { buttonValue: (responseToParse as { buttonValue: string })?.buttonValue, selectedValues: (responseToParse as { selectedValues?: string[] })?.selectedValues },
               conditionalText,
               dataToUpdate,
             );
+            console.log("[PATCH] Stored blockchain_experience:", dataToUpdate.blockchain_experience);
+            console.log("[PATCH] Stored blockchain_platforms:", dataToUpdate.blockchain_platforms);
             break;
-          }
-          case 3:
+          case 4:
             parseAI(
               responseToParse as { buttonValue: string } | null,
               conditionalText,
               dataToUpdate,
             );
             break;
-          case 4:
-            dataToUpdate.tools_familiarity =
-              (responseToParse as { buttonValue: string })?.buttonValue ?? null;
-            break;
           case 5:
-            dataToUpdate.experience_level =
+            dataToUpdate.tools_familiarity =
               (responseToParse as { buttonValue: string })?.buttonValue ?? null;
             break;
           case 6:

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -734,7 +734,6 @@ export function ChatContainer({
     )
       return;
 
-    // Special handling for AI/ML (index 7): merge conditionalText if 'Other' is selected and custom text is provided
     let selections = multiSelectAnswers[currentQuestionIndex];
     if (
       currentQuestionIndex === 7 &&
@@ -766,15 +765,17 @@ export function ChatContainer({
     setInputDisabled(true);
     try {
       let payload;
-      if (currentQuestionIndex === 1) {
+      if (currentQuestionIndex === 2) {
         // Languages: send as array
         payload = { sessionId, response: selections };
-      } else if (currentQuestionIndex === 2) {
+        console.log("[PATCH] Sending languages payload:", payload);
+      } else if (currentQuestionIndex === 3) {
         // Blockchain platforms: send as { selectedValues, buttonValue }
         payload = {
           sessionId,
           response: { selectedValues: selections, buttonValue: "Yes" },
         };
+        console.log("[PATCH] Sending blockchain platforms payload:", payload);
       } else if (currentQuestionIndex === 6) {
         // Hackathon: send as { selectedValues }
         payload = { sessionId, response: { selectedValues: selections } };

--- a/src/lib/questionnaire.ts
+++ b/src/lib/questionnaire.ts
@@ -33,7 +33,7 @@ const questions: QuestionDetail[] = [
   // Index 1 (Technical expertise, moved up)
   {
     index: 1,
-    text: "If you had to rate your technical expertise, where would you put yourself?",
+    text: "Nice to meet you, {name}! If you had to rate your technical expertise, where would you put yourself?",
     inputMode: "buttons",
     options: [
       { label: "1. Beginner", value: "Beginner" },
@@ -45,7 +45,7 @@ const questions: QuestionDetail[] = [
   // Index 2 (Programming Languages)
   {
     index: 2,
-    text: "Nice to meet you, {name}! If you are a programmer, which programming languages do you feel most at home with? (Pick as many as you like, or select 'I'm not a programmer.' if that's you.)",
+    text: "If you are a programmer, which programming languages do you feel most at home with? (Pick as many as you like, or select 'I'm not a programmer.' if that's you.)",
     inputMode: "buttons",
     options: [
       { label: "1. Rust", value: "Rust" },

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -71,7 +71,6 @@ export async function saveOnboardingResponse(
     github: data.github ?? null,
     x_handle: data.x ?? null, // Map 'x' from OnboardingData to 'x_handle' in DB type
     languages: data.languages ?? null,
-    other_languages: data.other_languages ?? null,
     blockchain_experience: data.blockchain_experience ?? null,
     blockchain_platforms: data.blockchain_platforms ?? null,
     ai_experience: data.ai_experience ?? null,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,6 @@ export interface OnboardingData {
   github?: string | null; // Q3 Parsed Handle
   x?: string | null; // Q3 Parsed Handle (Interface uses 'x')
   languages?: string[] | null; // Q4 Parsed Language Names
-  other_languages?: string | null; // Q4 Text from 'Other'
   blockchain_experience?: string | null; // Q5 Button Value ('Yes', 'No - curious', 'No experience')
   blockchain_platforms?: string[] | null; // Q5 Conditional Text
   ai_experience?: string | null; // Q6 Button Value ('Yes', 'No')
@@ -42,7 +41,6 @@ export interface OnboardingResponseForDB {
   github?: string | null;
   x_handle?: string | null; // Matches DB column name 'x_handle'
   languages?: string[] | null;
-  other_languages?: string | null;
   blockchain_experience?: string | null;
   blockchain_platforms?: string[] | null;
   ai_experience?: string | null;


### PR DESCRIPTION
Reorders the "Technical Expertise" and "Programming Languages" questions (indices 1 and 2) in the onboarding flow and updates associated logic.

- Swap text and index positions for technical expertise and languages questions in `questionnaire.ts`.
- Move greeting "{name}" to the new technical expertise question (index 1).
- Update the API route's POST handler (`route.ts`) to process responses based on the new question indices.
- Remove `other_languages` field from `OnboardingData` and `OnboardingResponseForDB` types (`types.ts`).
- Update `parseLanguages` and `parseBlockchain` functions (`parsing.ts`) to remove `other_languages` handling and refine parsing logic.
- Remove `other_languages` saving from `saveOnboardingResponse` (`supabase.ts`).
- Update `ChatContainer` (`chat-container.tsx`) to send language and blockchain payloads using the new question indices.
- Refactor API route tests (`route.test.ts`) to align with new question order, remove `validateInput` mocks/assertions, adjust session mock setup and assertions, and remove checks related to `other_languages`.