### PR TITLE
Implement chat restart and session persistence

### DIFF
--- a/src/app/api/onboarding/restart/route.ts
+++ b/src/app/api/onboarding/restart/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { createSession } from "@/lib/session";
+import { getQuestionDetails } from "@/lib/questionnaire";
+
+export async function POST() {
+    console.log("Restart API endpoint called");
+
+    try {
+        // Create a new session
+        const { sessionId } = await createSession();
+        console.log(`Created new session for restart: ${sessionId}`);
+
+        // Get the first question
+        const firstQuestion = getQuestionDetails(0);
+
+        if (!firstQuestion) {
+            return NextResponse.json(
+                { error: "Could not initialize the first question." },
+                { status: 500 }
+            );
+        }
+
+        // Return the session info and first question
+        return NextResponse.json({
+            success: true,
+            sessionId,
+            currentQuestionIndex: 0,
+            nextQuestion: firstQuestion.text,
+            inputMode: firstQuestion.inputMode,
+            options: firstQuestion.options || [],
+            conditionalTextInputLabel: firstQuestion.conditionalTextInputLabel,
+            conditionalTriggerValue: firstQuestion.conditionalTriggerValue,
+        });
+    } catch (error) {
+        console.error("Error creating new session for restart:", error);
+        return NextResponse.json(
+            { error: "Failed to restart the conversation. Please try again." },
+            { status: 500 }
+        );
+    }
+} 


### PR DESCRIPTION
- Add new API endpoint `/api/onboarding/restart` to create a new session and return the first question.
- Update `ChatContainer` to use the restart API, clear local storage, reset chat state, and re-initialize the conversation.
- Persist onboarding session ID in local storage across page loads.
- Add a key to force `ChatInput` remount during restart.
- Refine `ChatInput` focus logic and add checks for message sending callbacks.
- Add extensive console logging for debugging chat flow and input handling.