### PR TITLE
Add API route and client sync for onboarding back

### DIFF
--- a/src/app/api/onboarding/back/route.ts
+++ b/src/app/api/onboarding/back/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession, updateSession } from "@/lib/session";
+
+interface BackRequestPayload {
+    sessionId: string;
+    targetQuestionIndex: number;
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const requestData = await request.json();
+        const { sessionId, targetQuestionIndex } = requestData as BackRequestPayload;
+
+        if (!sessionId) {
+            return NextResponse.json(
+                { error: "Session ID is required" },
+                { status: 400 }
+            );
+        }
+
+        if (typeof targetQuestionIndex !== "number" || targetQuestionIndex < 0) {
+            return NextResponse.json(
+                { error: "Invalid target question index" },
+                { status: 400 }
+            );
+        }
+
+        // Retrieve the current session
+        const session = await getSession(sessionId);
+        if (!session) {
+            return NextResponse.json(
+                { error: "Session not found" },
+                { status: 404 }
+            );
+        }
+
+        // Update the current question index in the session
+        session.questionIndex = targetQuestionIndex;
+
+        // Clear any reprompt flags
+        session.repromptedIndex = null;
+
+        // Update the session
+        await updateSession(sessionId, session);
+
+        // Return success
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Error handling back navigation:", error);
+        return NextResponse.json(
+            { error: "Failed to process back navigation" },
+            { status: 500 }
+        );
+    }
+} 

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -1161,7 +1161,28 @@ export function ChatContainer({
     setIsProcessing(false);
     setHighlightedButtonIndex(null); // Reset keyboard navigation
 
-  }, [currentQuestionIndex, isProcessing, messages, questionHistory.messages]);
+    // Notify the server about the navigation back to synchronize state
+    if (sessionId) {
+      fetch("/api/onboarding/back", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          sessionId,
+          targetQuestionIndex: prevIndex
+        }),
+      })
+        .then(response => {
+          if (!response.ok) {
+            console.error("Failed to synchronize back navigation with server:", response.statusText);
+          }
+        })
+        .catch(error => {
+          console.error("Error synchronizing back navigation:", error);
+        });
+    }
+  }, [currentQuestionIndex, isProcessing, messages, questionHistory.messages, sessionId]);
 
   // Add a handler to reset all chat state and start a new session
   const handleRestart = async () => {


### PR DESCRIPTION
- Create new `/api/onboarding/back` POST endpoint to handle server-side state update.
- The endpoint updates the session's `questionIndex` to the target index and clears `repromptedIndex`.
- Call this API from `ChatContainer`'s `handleBack` function to synchronize state when navigating back.