### PR TITLE
feat: Add final recommendation intro and refactor chat init

### DIFF
--- a/src/app/api/onboarding/message/route.ts
+++ b/src/app/api/onboarding/message/route.ts
@@ -22,7 +22,7 @@ import {
   parseAI,
   // Import other parsing functions if created
 } from "@/lib/parsing";
-import { determinePath } from "@/lib/pathDetermination";
+import { determinePath, getFinalRecommendationIntro } from "@/lib/pathDetermination"; // Added getFinalRecommendationIntro
 import { saveOnboardingResponse } from "@/lib/supabase";
 import { OnboardingData, SessionState } from "@/lib/types"; // Ensure all needed types are imported
 
@@ -593,10 +593,17 @@ export async function POST(request: NextRequest) {
       );
 
       // 3d. Return Final Result for successful saves
+      const introductoryMessage = getFinalRecommendationIntro(
+        finalData.name,
+        recommendedPath,
+        finalData.goal
+      );
+
       return NextResponse.json(
         createResponsePayload({
           sessionId: currentSessionId,
           currentQuestionIndex: nextQuestionIndex, // Index is now >= TOTAL_QUESTIONS
+          nextQuestion: introductoryMessage, // <-- ADDED THIS LINE
           isFinalQuestion: true, // Signifies flow end
           finalResult: {
             recommendedPath,

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -304,8 +304,7 @@ export function ChatMessages({
                       </div>
                     )}
 
-                  {message.content === "__FINAL_RECOMMENDATION__" &&
-                    message.finalResult != null ? (
+                  {message.finalResult != null ? ( // Condition changed to only check for finalResult
                     (() => {
                       // Debug info to console
                       console.log("Recommended paths data:", {

--- a/src/lib/pathDetermination.ts
+++ b/src/lib/pathDetermination.ts
@@ -163,6 +163,29 @@ export function determinePath(data: OnboardingData): PathResult {
         secondRecommendedPathDescription,
     };
 }
+
+// New helper function
+export function getFinalRecommendationIntro(
+    userName: string | null | undefined,
+    recommendedPath: string,
+    userGoals?: string[] | null
+): string {
+    let intro = `Thanks${userName ? `, ${userName}` : ''}, for sharing your goals and interests! `;
+    intro += `Based on your responses, I recommend the **${recommendedPath}** for you. `;
+
+    // Add a more specific reason if possible (this is a simple example)
+    if (recommendedPath === "Visionary" && userGoals?.includes("Share ideas for new features")) {
+        intro += "This path is perfect for contributing your innovative ideas. ";
+    } else if (recommendedPath === "Hacker" && userGoals?.includes("Earn bounties")) {
+        intro += "This path will help you find challenges and earn bounties. ";
+    } else if (recommendedPath === "Explorer" && userGoals?.includes("Learn Web3 basics")) {
+        intro += "This path is great for learning the fundamentals. ";
+    }
+    // Add more conditions for other paths and goals as desired
+
+    intro += `Below, you will find more details and how to get started.`;
+    return intro;
+}
 // ---
 // For more details, see PATH_RULES_GUIDE.md in the root.
 // ---


### PR DESCRIPTION
- Add `getFinalRecommendationIntro` function to generate a user-specific message introducing the recommended path (`lib/pathDetermination.ts`).
- Include this message in the final API response (`api/onboarding/message/route.ts`) and display it in the chat by simplifying the rendering condition in `ChatMessages` (`chat-messages.tsx`).
- Refactor `ChatContainer` initialization (`chat-container.tsx`) using a `useRef` (`hasSuccessfullyStartedConversation`) to prevent duplicate `startConversation` calls, particularly in Strict Mode. Updates `initializeChat`, `startConversation`, and `handleRestart`.
- Clear sidebar state (`andromeda-onboarding-sidebar-opened`) from local storage on chat restart (`chat-container.tsx`).