### PR TITLE
Feat: Introduce Command Center navigation component

### DIFF
--- a/src/app/ai-navigators/page.tsx
+++ b/src/app/ai-navigators/page.tsx
@@ -6,6 +6,7 @@ import { Metadata } from "next";
 import { GitHubIssue } from "@/lib/github";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Button } from "@/components/ui/button";
+import { CommandCenterNav } from "@/components/layout/CommandCenterNav";
 import {
   Lightbulb,
   Wrench, // For AI Tooling & Frameworks
@@ -134,6 +135,9 @@ export default async function AINavigatorsPage() {
 
   return (
     <main className="container mx-auto p-4 md:p-6 max-w-7xl min-h-screen bg-[#1a1a1a] text-white">
+      {/* Command Center Navigation */}
+      <CommandCenterNav />
+
       <div className="mb-12 text-center">
         <h1 className="text-4xl font-bold text-white mb-3">
           🧭 AI Navigator 🧭

--- a/src/app/ambassador/page.tsx
+++ b/src/app/ambassador/page.tsx
@@ -1,5 +1,6 @@
 import { Award } from "lucide-react";
 import { DiveInSection } from "@/components/ui/DiveInSection";
+import { CommandCenterNav } from "@/components/layout/CommandCenterNav";
 
 export const metadata = {
   title: "Ambassador Path | Andromeda Protocol",
@@ -11,6 +12,9 @@ export default function AmbassadorPage() {
   return (
     <main className="min-h-screen bg-[#1a1a1a] text-white">
       <div className="container mx-auto p-4 md:p-6">
+        {/* Command Center Navigation */}
+        <CommandCenterNav />
+
         <div className="mb-8 text-center">
           <h1 className="text-3xl font-bold mb-4 text-white flex items-center justify-center gap-2">
             🏆 <Award className="w-8 h-8 text-[#e74c3c]" /> Ambassador 🏆

--- a/src/app/contractors/page.tsx
+++ b/src/app/contractors/page.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { MissionCard } from "@/components/cards/MissionCard";
 import VideoCarousel from "@/components/VideoCarousel";
 import { CampaignModal } from "@/components/CampaignModal";
+import { CommandCenterNav } from "@/components/layout/CommandCenterNav";
 
 export const metadata = {
   title: "Contractor Hub | Andromeda Protocol",
@@ -163,17 +164,8 @@ export default async function ContractorsPage() {
 
   return (
     <main className="container mx-auto p-4 md:p-6 max-w-full min-h-screen bg-[#1a1a1a] text-white">
-      {/* Header Section */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-white mb-2">
-          Contractor Command Center
-        </h1>
-        <div className="bg-[#1a1a1a] rounded-lg p-6 mb-12 w-full">
-          <p className="text-gray-400">
-            Hey there! Welcome to our learning dashboard. This is your go-to spot for missions, guides, and docs -- everything you need to dive into Andromeda smoothly.
-          </p>
-        </div>
-      </div>
+      {/* Command Center Navigation */}
+      <CommandCenterNav />
 
       {/* Main Layout: Left Content + Right Sidebar */}
       <div className="flex gap-6">

--- a/src/app/explorer/page.tsx
+++ b/src/app/explorer/page.tsx
@@ -1,5 +1,6 @@
 import { BookOpen } from "lucide-react";
 import { DiveInSection } from "@/components/ui/DiveInSection";
+import { CommandCenterNav } from "@/components/layout/CommandCenterNav";
 
 export const metadata = {
   title: "Explorer Path | Andromeda Protocol",
@@ -11,6 +12,9 @@ export default function ExplorerPage() {
   return (
     <main className="min-h-screen bg-[#1a1a1a] text-white">
       <div className="container mx-auto p-4 md:p-6">
+        {/* Command Center Navigation */}
+        <CommandCenterNav />
+
         <div className="mb-8 text-center">
           <h1 className="text-3xl font-bold mb-4 text-white flex items-center justify-center gap-2">
             🗺️ <BookOpen className="w-8 h-8 text-[#3498db]" /> Explorer 🗺️

--- a/src/app/hackers/page.tsx
+++ b/src/app/hackers/page.tsx
@@ -3,6 +3,7 @@ import { fetchGitHubIssues } from "@/lib/github";
 import { IssueCard } from "@/components/cards/IssueCard";
 import { IssueCardSkeleton } from "@/components/cards/IssueCardSkeleton";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { CommandCenterNav } from "@/components/layout/CommandCenterNav";
 
 export const metadata = {
   title: "Hacker Hub | Andromeda Protocol",
@@ -33,6 +34,9 @@ export default async function HackersPage() {
 
   return (
     <main className="container mx-auto p-4 md:p-6 max-w-7xl min-h-screen bg-[#1a1a1a] text-white">
+      {/* Command Center Navigation */}
+      <CommandCenterNav />
+
       <div className="mb-8 text-center">
         <h1 className="text-3xl font-bold text-white mb-2">
           🔥 Hacker Command Center 🔥

--- a/src/app/visionaries/page.tsx
+++ b/src/app/visionaries/page.tsx
@@ -7,6 +7,7 @@ import {
   Sparkles,
 } from "lucide-react"; // Added MessageSquare, Sparkles, removed FilePlus2
 import { Button } from "@/components/ui/button";
+import { CommandCenterNav } from "@/components/layout/CommandCenterNav";
 
 export const metadata: Metadata = {
   title: "Visionary Path | Andromeda Protocol",
@@ -20,6 +21,9 @@ export default function VisionariesPage() {
 
   return (
     <main className="container mx-auto p-4 md:p-6 max-w-7xl min-h-screen bg-[#1a1a1a] text-white">
+      {/* Command Center Navigation */}
+      <CommandCenterNav />
+
       {/* Removed redundant inner container div */}
       <div className="mb-8 text-center">
         <h1 className="text-3xl font-bold mb-4 text-white">💡 Visionary 💡</h1>

--- a/src/components/layout/CommandCenterNav.tsx
+++ b/src/components/layout/CommandCenterNav.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Briefcase,
+  Target,
+  Lightbulb,
+  BrainCircuit,
+  Award,
+  BookOpen,
+  ChevronDown,
+} from "lucide-react";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const commandCenterItems: NavItem[] = [
+  {
+    href: "/contractors",
+    label: "Contractor",
+    icon: <Briefcase className="w-4 h-4" />,
+  },
+  {
+    href: "/hackers",
+    label: "Hacker",
+    icon: <Target className="w-4 h-4" />,
+  },
+  {
+    href: "/visionaries",
+    label: "Visionary",
+    icon: <Lightbulb className="w-4 h-4" />,
+  },
+  {
+    href: "/ai-navigators",
+    label: "AI Navigator",
+    icon: <BrainCircuit className="w-4 h-4" />,
+  },
+  {
+    href: "/ambassador",
+    label: "Ambassador",
+    icon: <Award className="w-4 h-4" />,
+  },
+  {
+    href: "/explorer",
+    label: "Explorer",
+    icon: <BookOpen className="w-4 h-4" />,
+  },
+];
+
+export function CommandCenterNav() {
+  const pathname = usePathname();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  // Find the current active item
+  const currentItem =
+    commandCenterItems.find((item) => item.href === pathname) ||
+    commandCenterItems[0];
+
+  return (
+    <div className="mb-6">
+      {/* Dropdown Navigation with Command Center Label - Left Aligned */}
+      <div className="flex items-center justify-start gap-3 mb-4">
+        <div className="relative">
+          <button
+            onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+            className={cn(
+              "inline-flex items-center gap-2 px-4 py-2 rounded-md transition-all duration-200",
+              "text-sm font-medium bg-[#333333] text-white shadow-sm border border-[#444444]",
+              "hover:bg-[#404040] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[#1a1a1a]",
+            )}
+            aria-expanded={isDropdownOpen}
+            aria-haspopup="true"
+          >
+            {currentItem.icon}
+            <span>{currentItem.label}</span>
+            <ChevronDown
+              className={cn(
+                "w-4 h-4 transition-transform duration-200",
+                isDropdownOpen && "rotate-180",
+              )}
+            />
+          </button>
+
+          {/* Dropdown Menu */}
+          {isDropdownOpen && (
+            <>
+              {/* Backdrop to close dropdown when clicking outside */}
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsDropdownOpen(false)}
+              />
+
+              {/* Dropdown Content */}
+              <div className="absolute top-full left-0 mt-1 w-48 bg-[#2a2a2a] border border-[#444444] rounded-md shadow-lg z-20">
+                <div className="py-1">
+                  {commandCenterItems.map((item, index) => {
+                    const isActive = item.href === pathname;
+                    return (
+                      <Link
+                        key={index}
+                        href={item.href}
+                        onClick={() => setIsDropdownOpen(false)}
+                        className={cn(
+                          "flex items-center gap-2 px-4 py-2 text-sm transition-colors",
+                          isActive
+                            ? "bg-[#333333] text-white"
+                            : "text-gray-300 hover:bg-[#333333] hover:text-white",
+                        )}
+                      >
+                        {item.icon}
+                        <span>{item.label}</span>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Command Center Label */}
+        <span className="text-sm font-semibold uppercase tracking-wider text-gray-400">
+          Command Center
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Feat: Introduce Command Center navigation component

Create CommandCenterNav component for path-specific navigation. Add component to AI Navigators, Ambassador, Explorer, Hacker, and Visionary pages. Replace existing header on Contractor page with CommandCenterNav component.
```